### PR TITLE
Fix user api management page display errors

### DIFF
--- a/src/dashboards/user/pagesUser/Apis.tsx
+++ b/src/dashboards/user/pagesUser/Apis.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 
 interface ApiKey {
   id: string;
@@ -26,7 +26,6 @@ interface UsageLog {
 export default function Apis() {
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [usageLogs, setUsageLogs] = useState<UsageLog[]>([]);
-  const [showQuotaAlert, setShowQuotaAlert] = useState(false);
   const [selectedKey, setSelectedKey] = useState<ApiKey | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -134,11 +133,9 @@ export default function Apis() {
     );
   };
 
-  const checkQuotaAlerts = () => {
-    const alerts = apiKeys.filter(key => (key.quota.used / key.quota.limit) > 0.8);
-    setShowQuotaAlert(alerts.length > 0);
-    return alerts;
-  };
+  const quotaAlerts = useMemo(() => {
+    return apiKeys.filter(key => (key.quota.used / key.quota.limit) > 0.8);
+  }, [apiKeys]);
 
   const getQuotaPercentage = (used: number, limit: number) => (used / limit) * 100;
   const getQuotaColor = (percentage: number) => {
@@ -163,7 +160,7 @@ export default function Apis() {
       </div>
 
       {/* Alertes de quota */}
-      {checkQuotaAlerts().length > 0 && (
+      {quotaAlerts.length > 0 && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-4">
           <div className="flex">
             <div className="flex-shrink-0">
@@ -176,7 +173,7 @@ export default function Apis() {
               <div className="mt-2 text-sm text-red-700">
                 <p>Les clés API suivantes approchent de leur limite de quota :</p>
                 <ul className="list-disc list-inside mt-1">
-                  {checkQuotaAlerts().map(key => (
+                  {quotaAlerts.map(key => (
                     <li key={key.id}>{key.name} ({Math.round(getQuotaPercentage(key.quota.used, key.quota.limit))}% utilisé)</li>
                   ))}
                 </ul>

--- a/src/dashboards/user/pagesUser/Assistance.tsx
+++ b/src/dashboards/user/pagesUser/Assistance.tsx
@@ -1,6 +1,5 @@
 import { 
   MessageCircle,
-  X,
   Send,
   Plus,
   ArrowLeft,

--- a/src/dashboards/user/pagesUser/Document.tsx
+++ b/src/dashboards/user/pagesUser/Document.tsx
@@ -222,7 +222,7 @@ export default function Document() {
                 <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
                     <h3 className="text-xl font-bold text-gray-900 mb-4">Documents traités</h3>
                     <div className="space-y-4">
-                        {processedDocuments.map((doc, index) => (
+                        {processedDocuments.map((doc) => (
                             <div key={doc.id} className="border border-gray-200 rounded-lg p-4">
                                 <div className="flex items-center justify-between mb-3">
                                     <div className="flex items-center space-x-3">


### PR DESCRIPTION
Resolves "Gestion d'API" page not displaying for SA users by fixing a "Too many re-renders" error.

The page failed to render due to a `setState` call (`setShowQuotaAlert`) being executed directly during the render phase in `src/dashboards/user/pagesUser/Apis.tsx`, leading to an infinite re-render loop. This PR replaces the state-based quota alert check with a `useMemo` hook to prevent state updates during rendering. Minor unused imports and variables were also cleaned up.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bc7ff1a-861e-4b45-b49d-6f9390e8da03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bc7ff1a-861e-4b45-b49d-6f9390e8da03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

