### PR TITLE
Afficher page 2FA avant redirection dashboard

### DIFF
--- a/src/auth/Login.tsx
+++ b/src/auth/Login.tsx
@@ -43,9 +43,11 @@ export default function Login() {
     }
     
     if(email === "admin@gmail.com" && motDePasse === "Admin123@") {
-      window.location.href = "/admin";
+      localStorage.setItem("redirectAfterOTP", "/admin");
+      window.location.href = "/otp";
     } else if(email === "user@gmail.com" && motDePasse === "User123@") {
-      window.location.href = "/user";
+      localStorage.setItem("redirectAfterOTP", "/user");
+      window.location.href = "/otp";
     } else {
       setErreur("Email ou mot de passe incorrect");
     }
@@ -59,7 +61,7 @@ export default function Login() {
     
     setMessageEnvoi("Un code de réinitialisation OTP a été envoyé à votre adresse email.");
     console.log("Réinitialisation pour:", email);
-    // Rediriger vers la page OTP
+    localStorage.setItem("redirectAfterOTP", "/reinitialisation");
     window.location.href = "/otp";
   };
 

--- a/src/auth/PageOTP.tsx
+++ b/src/auth/PageOTP.tsx
@@ -92,7 +92,9 @@ export default function PageOTP() {
         
         // Redirection après 2 secondes
         setTimeout(() => {
-          window.location.href = "/reinitialisation";
+          const target = localStorage.getItem("redirectAfterOTP") || "/";
+          localStorage.removeItem("redirectAfterOTP");
+          window.location.href = target;
         }, 2000);
       } else {
         setErreurCode("Code incorrect. Veuillez réessayer.");

--- a/src/dashboards/user/pagesUser/Apis.tsx
+++ b/src/dashboards/user/pagesUser/Apis.tsx
@@ -26,7 +26,6 @@ interface UsageLog {
 export default function Apis() {
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [usageLogs, setUsageLogs] = useState<UsageLog[]>([]);
-  const [showQuotaAlert, setShowQuotaAlert] = useState(false);
   const [selectedKey, setSelectedKey] = useState<ApiKey | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -136,7 +135,6 @@ export default function Apis() {
 
   const checkQuotaAlerts = () => {
     const alerts = apiKeys.filter(key => (key.quota.used / key.quota.limit) > 0.8);
-    setShowQuotaAlert(alerts.length > 0);
     return alerts;
   };
 

--- a/src/dashboards/user/pagesUser/Assistance.tsx
+++ b/src/dashboards/user/pagesUser/Assistance.tsx
@@ -1,6 +1,5 @@
 import { 
   MessageCircle,
-  X,
   Send,
   Plus,
   ArrowLeft,

--- a/src/dashboards/user/pagesUser/Document.tsx
+++ b/src/dashboards/user/pagesUser/Document.tsx
@@ -222,7 +222,7 @@ export default function Document() {
                 <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
                     <h3 className="text-xl font-bold text-gray-900 mb-4">Documents traités</h3>
                     <div className="space-y-4">
-                        {processedDocuments.map((doc, index) => (
+                        {processedDocuments.map((doc) => (
                             <div key={doc.id} className="border border-gray-200 rounded-lg p-4">
                                 <div className="flex items-center justify-between mb-3">
                                     <div className="flex items-center space-x-3">


### PR DESCRIPTION
Implement 2FA redirection after login to display an OTP page before dashboard access.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1967e5c-a46a-41be-8b20-7203d6be0e5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1967e5c-a46a-41be-8b20-7203d6be0e5b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

